### PR TITLE
Hotfix/replace helper function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "~3|~4",
+        "orchestra/testbench": "~3|~4|~5|~6|~7",
         "sempro/phpunit-pretty-print": "^1.0"
     },
     "autoload": {

--- a/src/CachedAddressFinder.php
+++ b/src/CachedAddressFinder.php
@@ -3,6 +3,7 @@
 namespace CyberDuck\AddressFinder;
 
 use CyberDuck\AddressFinder\Drivers\DriverContract;
+use Illuminate\Support\Str;
 
 /**
  * Class CachedAddressFinder
@@ -56,11 +57,20 @@ class CachedAddressFinder extends AddressFinder
     }
 
     /**
+     * @param $slug
+     * @return string
+     */
+    private static function makeSlug($slug): string
+    {
+        return Str::of($slug)->slug('-');
+    }
+
+    /**
      * @param $params
      * @return string
      */
     private function buildCacheKey($params)
     {
-        return implode('-', array_map('str_slug', $params));
+        return implode('-', array_map('self::makeSlug', $params));
     }
 }

--- a/src/Drivers/LoqateDriver.php
+++ b/src/Drivers/LoqateDriver.php
@@ -6,6 +6,7 @@ use CyberDuck\AddressFinder\Details;
 use CyberDuck\AddressFinder\Suggestions;
 use Http;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
 
 /**
  * Class LoqateDriver
@@ -114,7 +115,7 @@ class LoqateDriver implements DriverContract
          */
         $details = app(Details::class);
 
-        $addressDetails = array_first($response['Items']) ?? null;
+        $addressDetails = Arr::first($response['Items']) ?? null;
 
         if (! $addressDetails) {
             return $details;

--- a/src/Drivers/MockDriver.php
+++ b/src/Drivers/MockDriver.php
@@ -5,6 +5,7 @@ namespace CyberDuck\AddressFinder\Drivers;
 use CyberDuck\AddressFinder\Details;
 use CyberDuck\AddressFinder\Suggestions;
 use Faker\Generator;
+use Illuminate\Support\Arr;
 
 /**
  * Class MockDriver
@@ -399,7 +400,7 @@ class MockDriver implements DriverContract
          */
         $details = app(Details::class);
 
-        $addressDetails = array_first($response['Items']) ?? null;
+        $addressDetails = Arr::first($response['Items']) ?? null;
 
         if (!$addressDetails) {
             return $details;


### PR DESCRIPTION
- replaced the old helper functions `str_slug` and `array_first` with the new class-based helpers
- updated the `orchestra/testbench` package to support laravel 9