### PR TITLE
Add ability to fetch translated Loqate address

### DIFF
--- a/src/AddressFinder.php
+++ b/src/AddressFinder.php
@@ -25,11 +25,12 @@ class AddressFinder
     /**
      * @param $addressId
      * @param bool $raw
+     * @param bool $translated
      * @return Details|array
      */
-    public function details($addressId, bool $raw = false)
+    public function details($addressId, bool $raw = false, bool $translated = false)
     {
-        return $this->addressEngine()->getDetails($addressId, $raw);
+        return $this->addressEngine()->getDetails($addressId, $raw, $translated);
     }
 
     /**

--- a/src/Drivers/DriverContract.php
+++ b/src/Drivers/DriverContract.php
@@ -18,7 +18,8 @@ interface DriverContract
     /**
      * @param $id
      * @param bool $raw
+     * @param bool $translated
      * @return Details
      */
-    public function getDetails($id, bool $raw = false);
+    public function getDetails($id, bool $raw = false, bool $translated = false);
 }

--- a/src/Drivers/MockDriver.php
+++ b/src/Drivers/MockDriver.php
@@ -139,9 +139,7 @@ class MockDriver implements DriverContract
      */
     public function parseSuggestions($response)
     {
-        /**
-         * @var $suggestions Suggestions
-         */
+        /** @var Suggestions $suggestions */
         $suggestions = app(Suggestions::class);
 
         foreach($response['Items'] ?? [] as $item) {
@@ -162,9 +160,11 @@ class MockDriver implements DriverContract
 
     /**
      * @param $id
+     * @param bool $raw
+     * @param bool $translated
      * @return Details
      */
-    public function getDetails($id, bool $raw = false)
+    public function getDetails($id, bool $raw = false, bool $translated = false)
     {
         $addresses = [
             'default' => [
@@ -385,23 +385,23 @@ class MockDriver implements DriverContract
 
         ];
 
-        return $this->parseDetails($addresses[$id], $raw);
+        return $this->parseDetails($addresses[$id], $raw, $translated);
     }
 
     /**
      * @param $response
+     * @param bool $raw
+     * @param bool $translated
      * @return Details|array
      */
-    public function parseDetails($response, bool $raw = false)
+    public function parseDetails($response, bool $raw = false, bool $translated = false)
     {
-        /**
-         * @var $details Details
-         */
+        /** @var Details $details */
         $details = app(Details::class);
 
         $addressDetails = array_first($response['Items']) ?? null;
 
-        if (!$addressDetails) {
+        if (! $addressDetails) {
             return $details;
         }
 

--- a/src/Facades/Address.php
+++ b/src/Facades/Address.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static Suggestions suggestions($query, $country, $group_id)
- * @method static Details details($id, $raw = false)
+ * @method static Details details($id, bool $raw = false, bool $translated = false)
  *
  * @see \CyberDuck\AddressFinder\AddressFinder
  *


### PR DESCRIPTION
When fetching an address by ID, Loqate provides multiple versions of this address in different languages, such as the native language for the address and English.

It is sometimes required to have the English version of the address, such as for FedEx shipments to China where FedEx only supports ASCII characters.