### PR TITLE
Feature/allow optional return of raw loqate response and include custom fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     "homepage": "https://github.com/cyber-duck/laravel-address-finder",
     "keywords": ["Laravel", "laravel-address-finder"],
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.0",
         "illuminate/support": "~5|~6|~7|~8|~9"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "~3|~4",
+        "orchestra/testbench": "~3|~4|~5|~6|~7",
         "sempro/phpunit-pretty-print": "^1.0"
     },
     "autoload": {

--- a/src/AddressFinder.php
+++ b/src/AddressFinder.php
@@ -15,22 +15,24 @@ class AddressFinder
      * @param $query
      * @param $country
      * @param $group_id
-     * @return Suggestions
+     * @param bool $raw
+     * @return Suggestions|array
      */
-    public function suggestions($query, $country, $group_id)
+    public function suggestions($query, $country, $group_id, bool $raw = false): Suggestions|array
     {
-        return $this->addressEngine()->suggestions($query, $country, $group_id);
+        return $this->addressEngine()->suggestions($query, $country, $group_id, $raw);
     }
 
     /**
      * @param $addressId
      * @param bool $raw
      * @param bool $translated
+     * @param array $customFields
      * @return Details|array
      */
-    public function details($addressId, bool $raw = false, bool $translated = false)
+    public function details($addressId, bool $raw = false, bool $translated = false, array $customFields = [])
     {
-        return $this->addressEngine()->getDetails($addressId, $raw, $translated);
+        return $this->addressEngine()->getDetails($addressId, $raw, $translated, $customFields);
     }
 
     /**

--- a/src/Details.php
+++ b/src/Details.php
@@ -50,6 +50,11 @@ class Details
     private $state;
 
     /**
+     * @var array
+     */
+    private $customFields = [];
+
+    /**
      * @return mixed
      */
     public function getPostalCode()
@@ -197,11 +202,29 @@ class Details
     }
 
     /**
+     * @return mixed
+     */
+    public function getCustomFields()
+    {
+        return $this->customFields;
+    }
+
+    /**
+     * @param mixed $customFields
+     * @return Details
+     */
+    public function setCustomFields($customFields): Details
+    {
+        $this->customFields = $customFields;
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function get()
     {
-        return [
+        return array_merge([
             'postal_code' => $this->getPostalCode(),
             'province_code' => $this->getProvinceCode() ?? '',
             'state' => $this->getState() ?? '',
@@ -210,6 +233,6 @@ class Details
             'address_line_1' => $this->getLine1(),
             'address_line_2' => $this->getLine2(),
             'address_line_3' => $this->getLine3(),
-        ];
+        ], $this->getCustomFields());
     }
 }

--- a/src/Drivers/DriverContract.php
+++ b/src/Drivers/DriverContract.php
@@ -11,15 +11,17 @@ interface DriverContract
      * @param $query
      * @param $country
      * @param $group_id
-     * @return Suggestions
+     * @param bool $raw
+     * @return Suggestions|array
      */
-    public function suggestions($query, $country, $group_id): Suggestions;
+    public function suggestions($query, $country, $group_id, bool $raw = false): Suggestions|array;
 
     /**
      * @param $id
      * @param bool $raw
      * @param bool $translated
+     * @param array $customFields
      * @return Details
      */
-    public function getDetails($id, bool $raw = false, bool $translated = false);
+    public function getDetails($id, bool $raw = false, bool $translated = false, array $customFields = []);
 }

--- a/src/Drivers/LoqateDriver.php
+++ b/src/Drivers/LoqateDriver.php
@@ -151,7 +151,7 @@ class LoqateDriver implements DriverContract
         $payload = ['Id' => $id];
 
         foreach ($customFields as $key => $value) {
-            $payload['Field' . $key + 1 . 'Format'] = $value;
+            $payload['Field' . ($key + 1) . 'Format'] = $value;
         }
 
         return $payload;
@@ -168,7 +168,7 @@ class LoqateDriver implements DriverContract
         if (! empty($customFields)) {
             foreach ($customFields as $key => $value) {
                 $newKey = Str::of($value)->replaceMatches('/[^A-Za-z0-9]++/', '')->lower()->toString();
-                $customFieldsResult[$newKey] = $addressDetails['Field' . $key + 1] ?? '';
+                $customFieldsResult[$newKey] = $addressDetails['Field' . ($key + 1)] ?? '';
             }
         }
 

--- a/src/Drivers/LoqateDriver.php
+++ b/src/Drivers/LoqateDriver.php
@@ -6,6 +6,8 @@ use CyberDuck\AddressFinder\Details;
 use CyberDuck\AddressFinder\Suggestions;
 use Http;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 /**
  * Class LoqateDriver
@@ -49,9 +51,10 @@ class LoqateDriver implements DriverContract
      * @param $query
      * @param $country
      * @param $group_id
-     * @return Suggestions
+     * @param bool $raw
+     * @return Suggestions|array
      */
-    public function suggestions($query, $country, $group_id): Suggestions
+    public function suggestions($query, $country, $group_id, bool $raw = false): Suggestions|array
     {
         return $this->parseSuggestions($this->client->get(
             $this->suggestionsEndpoint,
@@ -60,17 +63,22 @@ class LoqateDriver implements DriverContract
                 'Text' => $query,
                 'Countries' => $country,
             ]
-        )->json());
+        )->json(), $raw);
     }
 
     /**
      * @param $response
-     * @return Suggestions
+     * @param bool $raw
+     * @return Suggestions|array
      */
-    public function parseSuggestions($response)
+    public function parseSuggestions($response, bool $raw = false): Suggestions|array
     {
         /** @var Suggestions $suggestions */
         $suggestions = app(Suggestions::class);
+
+        if ($raw) {
+            return $response['Items'] ?? [];
+        }
 
         foreach ($response['Items'] ?? [] as $item) {
             if (!isset($item['Id'])) {
@@ -92,33 +100,49 @@ class LoqateDriver implements DriverContract
      * @param $id
      * @param bool $raw
      * @param bool $translated
+     * @param array $customFields
      * @return Details
      */
-    public function getDetails($id, bool $raw = false, bool $translated = false)
+    public function getDetails($id, bool $raw = false, bool $translated = false, array $customFields = [])
     {
+        $payload = ['Id' => $id];
+
+        foreach ($customFields as $key => $value) {
+            $payload['Field' . $key + 1 . 'Format'] = $value;
+        }
+
         return $this->parseDetails($this->client->get(
             $this->detailsEndpoint,
-            ['Id' => $id]
-        )->json(), $raw, $translated);
+            $payload
+        )->json(), $raw, $translated, $customFields);
     }
 
     /**
      * @param $response
      * @param bool $raw
      * @param bool $translated
+     * @param array $customFields
      * @return Details|array
      */
-    public function parseDetails($response, bool $raw = false, bool $translated = false)
+    public function parseDetails($response, bool $raw = false, bool $translated = false, array $customFields = [])
     {
         /** @var Details $details */
         $details = app(Details::class);
 
-        $addressDetails = array_first($response['Items'], function ($item) use ($translated) {
+        $addressDetails = Arr::first($response['Items'], function ($item) use ($translated) {
             return ! $translated || $item['Language'] === 'ENG';
         });
 
         if (! $addressDetails) {
             return $details;
+        }
+
+        $customFieldsResult = [];
+        if (! empty($customFields)) {
+            foreach ($customFields as $key => $value) {
+                $newKey = Str::of($value)->replaceMatches('/[^A-Za-z0-9]++/', '')->lower()->toString();
+                $customFieldsResult[$newKey] = $addressDetails['Field' . $key + 1] ?? '';
+            }
         }
 
         return $raw ? $addressDetails : $details->setPostalCode($addressDetails['PostalCode'] ?? '')
@@ -127,6 +151,7 @@ class LoqateDriver implements DriverContract
             ->setCity($addressDetails['City'])
             ->setLine1($addressDetails['Line1'])
             ->setLine2($addressDetails['Line2'])
-            ->setLine3($addressDetails['Line3']);
+            ->setLine3($addressDetails['Line3'])
+            ->setCustomFields($customFieldsResult);
     }
 }

--- a/src/Drivers/MockDriver.php
+++ b/src/Drivers/MockDriver.php
@@ -446,7 +446,7 @@ class MockDriver implements DriverContract
         if (! empty($customFields)) {
             foreach ($customFields as $key => $value) {
                 $newKey = Str::of($value)->replaceMatches('/[^A-Za-z0-9]++/', '')->lower()->toString();
-                $customFieldsResult[$newKey] = $addressDetails['Field' . $key + 1] ?? '';
+                $customFieldsResult[$newKey] = $addressDetails['Field' . ($key + 1)] ?? '';
             }
         }
 

--- a/src/Drivers/MockDriver.php
+++ b/src/Drivers/MockDriver.php
@@ -5,6 +5,8 @@ namespace CyberDuck\AddressFinder\Drivers;
 use CyberDuck\AddressFinder\Details;
 use CyberDuck\AddressFinder\Suggestions;
 use Faker\Generator;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 /**
  * Class MockDriver
@@ -36,15 +38,16 @@ class MockDriver implements DriverContract
      * @param $query
      * @param $country
      * @param $group_id
-     * @return Suggestions
+     * @param bool $raw
+     * @return Suggestions|array
      */
-    public function suggestions($query, $country, $group_id): Suggestions
+    public function suggestions($query, $country, $group_id, bool $raw = false): Suggestions|array
     {
         if (!empty($group_id)) {
-            return $this->parseSuggestions($this->getAddressChildrenResponse());
+            return $this->parseSuggestions($this->getAddressChildrenResponse(), $raw);
         }
 
-        return $this->parseSuggestions($this->getSuggestedAddressesResponse($country));
+        return $this->parseSuggestions($this->getSuggestedAddressesResponse($country), $raw);
     }
 
     /**
@@ -118,14 +121,14 @@ class MockDriver implements DriverContract
                 [
                     'Id' => 'ES|TT|A|17240004045469|1',
                     'Type' => 'Address',
-                    'Text' => $this->mockedAddress['address_line_1'] . ' ' . str_random(2),
+                    'Text' => $this->mockedAddress['address_line_1'] . ' ' . Str::random(2),
                     'Highlight' => '',
                     'Description' => "{$this->mockedAddress['postal_code']} {$this->mockedAddress['city']}",
                 ],
                 [
                     'Id' => 'ES|TT|A|17240010299823|1S',
                     'Type' => 'Address',
-                    'Text' => $this->mockedAddress['address_line_1'] . ' ' . str_random(2),
+                    'Text' => $this->mockedAddress['address_line_1'] . ' ' . Str::random(2),
                     'Highlight' => '',
                     'Description' => "{$this->mockedAddress['postal_code']} {$this->mockedAddress['city']}",
                 ],
@@ -135,12 +138,17 @@ class MockDriver implements DriverContract
 
     /**
      * @param $response
-     * @return Suggestions
+     * @param bool $raw
+     * @return Suggestions|array
      */
-    public function parseSuggestions($response)
+    public function parseSuggestions($response, bool $raw = false): Suggestions|array
     {
         /** @var Suggestions $suggestions */
         $suggestions = app(Suggestions::class);
+
+        if ($raw) {
+            return $response['Items'] ?? [];
+        }
 
         foreach($response['Items'] ?? [] as $item) {
             if (!isset($item['Id'])) {
@@ -162,9 +170,10 @@ class MockDriver implements DriverContract
      * @param $id
      * @param bool $raw
      * @param bool $translated
+     * @param array $customFields
      * @return Details
      */
-    public function getDetails($id, bool $raw = false, bool $translated = false)
+    public function getDetails($id, bool $raw = false, bool $translated = false, array $customFields = [])
     {
         $addresses = [
             'default' => [
@@ -207,6 +216,8 @@ class MockDriver implements DriverContract
                         'Label' => ' 32A Greville Street LONDON EC1N 8TB UNITED KINGDOM ',
                         'Type' => 'Residential',
                         'DataLevel' => 'Premise',
+                        'Field1' => '51.832993',
+                        'Field2' => '-3.041141',
                     ],
                 ],
             ],
@@ -250,6 +261,8 @@ class MockDriver implements DriverContract
                         'Label' => ' 32A Greville Street LONDON EC1N 8TB UNITED KINGDOM ',
                         'Type' => 'Residential',
                         'DataLevel' => 'Premise',
+                        'Field1' => '50.832993',
+                        'Field2' => '-0.041141',
                     ],
                 ],
             ],
@@ -293,6 +306,8 @@ class MockDriver implements DriverContract
                         'Label' => ' 15 Calle de Ulldecona PARIS 43520 FRANCE',
                         'Type' => 'Residential',
                         'DataLevel' => 'Premise',
+                        'Field1' => '48.832993',
+                        'Field2' => '0.041141',
                     ],
                 ],
             ],
@@ -336,6 +351,8 @@ class MockDriver implements DriverContract
                         'Label' => ' 15 Calle de Ulldecona PARIS 43520 FRANCE',
                         'Type' => 'Residential',
                         'DataLevel' => 'Premise',
+                        'Field1' => '55.832993',
+                        'Field2' => '-1.041141',
                     ],
                 ],
             ],
@@ -379,30 +396,41 @@ class MockDriver implements DriverContract
                         'Label' => ' 15 Calle de Ulldecona PARIS 43520 FRANCE',
                         'Type' => 'Residential',
                         'DataLevel' => 'Premise',
+                        'Field1' => '49.832993',
+                        'Field2' => '1.041141',
                     ],
                 ],
             ],
 
         ];
 
-        return $this->parseDetails($addresses[$id], $raw, $translated);
+        return $this->parseDetails($addresses[$id], $raw, $translated, $customFields);
     }
 
     /**
      * @param $response
      * @param bool $raw
      * @param bool $translated
+     * @param array $customFields
      * @return Details|array
      */
-    public function parseDetails($response, bool $raw = false, bool $translated = false)
+    public function parseDetails($response, bool $raw = false, bool $translated = false, array $customFields = [])
     {
         /** @var Details $details */
         $details = app(Details::class);
 
-        $addressDetails = array_first($response['Items']) ?? null;
+        $addressDetails = Arr::first($response['Items']) ?? null;
 
         if (! $addressDetails) {
             return $details;
+        }
+
+        $customFieldsResult = [];
+        if (! empty($customFields)) {
+            foreach ($customFields as $key => $value) {
+                $newKey = Str::of($value)->replaceMatches('/[^A-Za-z0-9]++/', '')->lower()->toString();
+                $customFieldsResult[$newKey] = $addressDetails['Field' . $key + 1] ?? '';
+            }
         }
 
         return $raw ? $addressDetails : $details->setPostalCode($addressDetails['PostalCode'] ?? '')
@@ -411,6 +439,7 @@ class MockDriver implements DriverContract
             ->setCity($addressDetails['City'])
             ->setLine1($addressDetails['Line1'])
             ->setLine2($addressDetails['Line2'])
-            ->setLine3($addressDetails['Line3']);
+            ->setLine3($addressDetails['Line3'])
+            ->setCustomFields($customFieldsResult);
     }
 }

--- a/src/Drivers/MockDriver.php
+++ b/src/Drivers/MockDriver.php
@@ -425,6 +425,23 @@ class MockDriver implements DriverContract
             return $details;
         }
 
+        return $raw ? $addressDetails : $details->setPostalCode($addressDetails['PostalCode'] ?? '')
+            ->setProvinceCode($addressDetails['ProvinceCode'] ?? '')
+            ->setCompany($addressDetails['Company'])
+            ->setCity($addressDetails['City'])
+            ->setLine1($addressDetails['Line1'])
+            ->setLine2($addressDetails['Line2'])
+            ->setLine3($addressDetails['Line3'])
+            ->setCustomFields($this->buildCustomFieldsForResponse($customFields, $addressDetails));
+    }
+
+    /**
+     * @param array $customFields
+     * @param array $addressDetails
+     * @return array
+     */
+    private function buildCustomFieldsForResponse(array $customFields, array $addressDetails): array
+    {
         $customFieldsResult = [];
         if (! empty($customFields)) {
             foreach ($customFields as $key => $value) {
@@ -433,13 +450,6 @@ class MockDriver implements DriverContract
             }
         }
 
-        return $raw ? $addressDetails : $details->setPostalCode($addressDetails['PostalCode'] ?? '')
-            ->setProvinceCode($addressDetails['ProvinceCode'] ?? '')
-            ->setCompany($addressDetails['Company'])
-            ->setCity($addressDetails['City'])
-            ->setLine1($addressDetails['Line1'])
-            ->setLine2($addressDetails['Line2'])
-            ->setLine3($addressDetails['Line3'])
-            ->setCustomFields($customFieldsResult);
+        return $customFieldsResult;
     }
 }

--- a/src/Facades/Address.php
+++ b/src/Facades/Address.php
@@ -7,8 +7,8 @@ use CyberDuck\AddressFinder\Suggestions;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static Suggestions suggestions($query, $country, $group_id)
- * @method static Details details($id, bool $raw = false, bool $translated = false)
+ * @method static Suggestions|array suggestions($query, $country, $group_id, bool $raw = false)
+ * @method static Details details($id, bool $raw = false, bool $translated = false, array $customFields = [])
  *
  * @see \CyberDuck\AddressFinder\AddressFinder
  *


### PR DESCRIPTION
- added optional bool parameter $raw to _suggestions_ to allow us to return the raw response from the loqate service.
- extended the _getDetails_ with an optional $customFields parameter that allows us to include custom fields like latitude and longitude on the response.